### PR TITLE
HTTPResponse object has no attribute 'readall'

### DIFF
--- a/download.py
+++ b/download.py
@@ -16,14 +16,14 @@ def get_links(client_id):
     headers = {'Authorization': 'Client-ID {}'.format(client_id)}
     req = Request('https://api.imgur.com/3/gallery/', headers=headers, method='GET')
     with urlopen(req) as resp:
-        data = json.loads(resp.readall().decode('utf-8'))
+        data = json.loads(resp.read().decode('utf-8'))
     return map(lambda item: item['link'], data['data'])
 
 
 def download_link(directory, link):
     download_path = directory / os.path.basename(link)
     with urlopen(link) as image, download_path.open('wb') as f:
-        f.write(image.readall())
+        f.write(image.read())
     logger.info('Downloaded %s', link)
 
 


### PR DESCRIPTION
get_links() and download_link throwing:

AttributeError: 'HTTPResponse' object has no attribute 'readall'

Changed 'readall' to 'read'